### PR TITLE
Create deployments from published releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ labels:
     payload:
       port: 8080
       https: true
+releases:
+  environment: production
 ```
 
 - Create matching labels in your repository


### PR DESCRIPTION
# Usage

- Add a `releases` section to `.github/deploy.yml`, e.g.:
```yaml
labels:
   ...
releases:
  environment: production
```
- Publish a new release to trigger a deployment
- Save draft and re-publish to trigger re-deployment

